### PR TITLE
Add class wide queue and queue completion block

### DIFF
--- a/YoutubeParser/Classes/HCYoutubeParser.h
+++ b/YoutubeParser/Classes/HCYoutubeParser.h
@@ -34,7 +34,29 @@ typedef enum {
     YouTubeThumbnailDefaultMaxQuality
 } YouTubeThumbnail;
 
+typedef void (^HCYoutubeParserQueueCompletionBlock)(NSOperationQueue *queueCompletionBlock);
+
+#define kHCYoutubeParserQueueCompleted @"kHCYoutubeParserQueueCompleted"
+
 @interface HCYoutubeParser : NSObject
+/**
+ You can specifiy a block which gets called once the queue is empty again
+ */
+@property (nonatomic, strong) HCYoutubeParserQueueCompletionBlock queueCompletionBlock;
+
+/**
+ In case you want to block your current thread with calling NSOperationQueue's
+ - (void)waitUntilAllOperationsAreFinished method, use this queue.
+ */
+@property (readonly, strong) NSOperationQueue *youtubeRequestQueue;
+
+/**
+ To make use of the global notification, we have to use 
+ only one queue which is tied to this shared instance.
+ 
+ @return shared instance of HCYoutubeParser
+ */
++ (HCYoutubeParser *)sharedInstance;
 
 /**
  Method for retrieving the youtube ID from a youtube URL
@@ -71,6 +93,17 @@ typedef enum {
  */
 + (void)h264videosWithYoutubeURL:(NSURL *)youtubeURL
                    completeBlock:(void(^)(NSDictionary *videoDictionary, NSError *error))completeBlock;
+
+/**
+ Block based method for retreiving a iOS supported video link
+ 
+ @param youtubeURL the the complete youtube video url
+ @param completeBlock the block which is called on completion
+ 
+ */
+- (void)h264videosWithYoutubeURL:(NSURL *)youtubeURL
+                   completeBlock:(void(^)(NSDictionary *videoDictionary, NSError *error))completeBlock;
+
 /**
  Method for retreiving a thumbnail for wanted youtube url
  
@@ -79,6 +112,17 @@ typedef enum {
  @param completeBlock the block which is called on completion
  */
 + (void)thumbnailForYoutubeURL:(NSURL *)youtubeURL
+                 thumbnailSize:(YouTubeThumbnail)thumbnailSize
+                 completeBlock:(void(^)(UIImage *image, NSError *error))completeBlock;
+
+/**
+ Method for retreiving a thumbnail for wanted youtube url
+ 
+ @param youtubeURL the the complete youtube video url
+ @param thumbnailSize the wanted size of the thumbnail
+ @param completeBlock the block which is called on completion
+ */
+- (void)thumbnailForYoutubeURL:(NSURL *)youtubeURL
                  thumbnailSize:(YouTubeThumbnail)thumbnailSize
                  completeBlock:(void(^)(UIImage *image, NSError *error))completeBlock;
 
@@ -93,6 +137,17 @@ typedef enum {
                 thumbnailSize:(YouTubeThumbnail)thumbnailSize
                 completeBlock:(void(^)(UIImage *image, NSError *error))completeBlock;
 
+/**
+ Method for retreiving a thumbnail for wanted youtube id
+ 
+ @param youtubeURL the complete youtube video id
+ @param thumbnailSize the wanted size of the thumbnail
+ @param completeBlock the block which is called on completion
+ */
+- (void)thumbnailForYoutubeID:(NSString *)youtubeID
+				thumbnailSize:(YouTubeThumbnail)thumbnailSize
+				completeBlock:(void (^)(UIImage *, NSError *))completeBlock;
+
 
 /**
  Method for retreiving all the details of a youtube video
@@ -103,4 +158,12 @@ typedef enum {
  */
 + (void)detailsForYouTubeURL:(NSURL *)youtubeURL
                completeBlock:(void(^)(NSDictionary *details, NSError *error))completeBlock;
+
+/**
+ By default we only handle 2 NSURLRequests at the same time, 
+ if you want more you can modify that
+ 
+ @param operation Number of concurrent NSURLRequests running at maximum
+ */
+- (void)setMaxConcurrentOperationCount:(NSUInteger)operationCount;
 @end

--- a/YoutubeParser/Classes/HCYoutubeParser.m
+++ b/YoutubeParser/Classes/HCYoutubeParser.m
@@ -190,7 +190,6 @@ static NSString * kHCYoutubeParserQueueOperationCountChanged = @"queue operation
                         
                         NSString *quality = [[[videoComponents objectForKey:@"quality"] objectAtIndex:0] stringByDecodingURLFormat];
                         
-                        NSLog(@"Found video for quality: %@", quality);
                         [videoDictionary setObject:url forKey:quality];
                     }
                 }
@@ -258,7 +257,6 @@ static NSString * kHCYoutubeParserQueueOperationCountChanged = @"queue operation
                             
                             NSString *quality = [[[videoComponents objectForKey:@"quality"] objectAtIndex:0] stringByDecodingURLFormat];
                             
-                            NSLog(@"Found video for quality: %@", quality);
                             [videoDictionary setObject:url forKey:quality];
                         }
                     }

--- a/YoutubeParser/Classes/HCYoutubeParser.m
+++ b/YoutubeParser/Classes/HCYoutubeParser.m
@@ -86,7 +86,61 @@
 
 @end
 
+@interface HCYoutubeParser()
+@property (nonatomic, strong) NSOperationQueue *youtubeRequestQueue;
+
+@end
+
 @implementation HCYoutubeParser
+static NSString * kHCYoutubeParserQueueOperationCountChanged = @"queue operationcount changed";
+
++ (HCYoutubeParser *)sharedInstance {
+    static HCYoutubeParser *sharedInstance;
+    @synchronized(self) {
+        if (sharedInstance == nil) {
+            sharedInstance = [[HCYoutubeParser alloc] init];
+        }
+    }
+    return sharedInstance;
+}
+
+- (id)init {
+	self = [super init];
+	if (self) {
+		_youtubeRequestQueue = [[NSOperationQueue alloc] init];
+		_youtubeRequestQueue.maxConcurrentOperationCount = 2;
+		[_youtubeRequestQueue addObserver:self forKeyPath:@"operationCount" options:0 context:&kHCYoutubeParserQueueOperationCountChanged];
+	}
+	return self;
+}
+
+- (void) observeValueForKeyPath:(NSString *)keyPath
+					   ofObject:(id)object
+                         change:(NSDictionary *)change
+						context:(void *)context {
+    if (context == &kHCYoutubeParserQueueOperationCountChanged
+		&& object == self.youtubeRequestQueue
+		&& [keyPath isEqualToString:@"operationCount"])
+	{
+        if (self.youtubeRequestQueue.operationCount == 0) {
+			if (self.queueCompletionBlock) {
+				self.queueCompletionBlock(self.youtubeRequestQueue);
+			}
+			
+			[[NSNotificationCenter defaultCenter] postNotificationName:kHCYoutubeParserQueueCompleted
+																object:nil
+															  userInfo:@{@"queue" : self.youtubeRequestQueue}];
+        }
+    }
+    else {
+        [super observeValueForKeyPath:keyPath ofObject:object
+                               change:change context:context];
+    }
+}
+
+- (void)setMaxConcurrentOperationCount:(NSUInteger)operationCount {
+	self.youtubeRequestQueue.maxConcurrentOperationCount = operationCount;
+}
 
 + (NSString *)youtubeIDFromYoutubeURL:(NSURL *)youtubeURL {
     NSString *youtubeID = nil;
@@ -157,8 +211,14 @@
 
 + (void)h264videosWithYoutubeURL:(NSURL *)youtubeURL
                    completeBlock:(void(^)(NSDictionary *videoDictionary, NSError *error))completeBlock {
+	HCYoutubeParser *ytParser = [HCYoutubeParser sharedInstance];
+	[ytParser h264videosWithYoutubeURL:youtubeURL completeBlock:completeBlock];
+}
+
+- (void)h264videosWithYoutubeURL:(NSURL *)youtubeURL
+                   completeBlock:(void(^)(NSDictionary *videoDictionary, NSError *error))completeBlock {
     
-    NSString *youtubeID = [self youtubeIDFromYoutubeURL:youtubeURL];
+    NSString *youtubeID = [HCYoutubeParser youtubeIDFromYoutubeURL:youtubeURL];
     
     if (youtubeID)
     {
@@ -168,9 +228,7 @@
         [request setValue:kUserAgent forHTTPHeaderField:@"User-Agent"];
         [request setHTTPMethod:@"GET"];
         
-        NSOperationQueue *queue = [[NSOperationQueue alloc] init];
-        
-        [NSURLConnection sendAsynchronousRequest:request queue:queue completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+        [NSURLConnection sendAsynchronousRequest:request queue:self.youtubeRequestQueue completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
             if (!error)
             {
                 NSString *responseString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
@@ -225,6 +283,11 @@
 }
 
 + (void)thumbnailForYoutubeID:(NSString *)youtubeID thumbnailSize:(YouTubeThumbnail)thumbnailSize completeBlock:(void (^)(UIImage *, NSError *))completeBlock {
+	HCYoutubeParser *ytParser = [HCYoutubeParser sharedInstance];
+	[ytParser thumbnailForYoutubeID:youtubeID thumbnailSize:thumbnailSize completeBlock:completeBlock];
+}
+
+- (void)thumbnailForYoutubeID:(NSString *)youtubeID thumbnailSize:(YouTubeThumbnail)thumbnailSize completeBlock:(void (^)(UIImage *, NSError *))completeBlock {
     if (youtubeID) {
         
         NSString *thumbnailSizeString = nil;
@@ -250,9 +313,12 @@
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
         [request setValue:kUserAgent forHTTPHeaderField:@"User-Agent"];
         [request setHTTPMethod:@"GET"];
+		
+		[self.youtubeRequestQueue isSuspended];
         
-        NSOperationQueue *queue = [[NSOperationQueue alloc] init];
-        [NSURLConnection sendAsynchronousRequest:request queue:queue completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+        [NSURLConnection sendAsynchronousRequest:request
+										   queue:self.youtubeRequestQueue
+							   completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
             if (!error) {
                 UIImage *image = [UIImage imageWithData:data];
                 completeBlock(image, nil);
@@ -274,15 +340,20 @@
 }
 
 + (void)detailsForYouTubeURL:(NSURL *)youtubeURL
+               completeBlock:(void(^)(NSDictionary *details, NSError *error))completeBlock {
+	HCYoutubeParser *ytParser = [HCYoutubeParser sharedInstance];
+	[ytParser detailsForYouTubeURL:youtubeURL completeBlock:completeBlock];
+}
+
+- (void)detailsForYouTubeURL:(NSURL *)youtubeURL
                completeBlock:(void(^)(NSDictionary *details, NSError *error))completeBlock
 {
-    NSString *youtubeID = [self youtubeIDFromYoutubeURL:youtubeURL];
+    NSString *youtubeID = [HCYoutubeParser youtubeIDFromYoutubeURL:youtubeURL];
     if (youtubeID)
     {
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:kYoutubeDataURL, youtubeID]]];
         
-        NSOperationQueue *queue = [[NSOperationQueue alloc] init];
-        [NSURLConnection sendAsynchronousRequest:request queue:queue completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+        [NSURLConnection sendAsynchronousRequest:request queue:self.youtubeRequestQueue completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
             if (!error) {
                 NSDictionary* json = [NSJSONSerialization JSONObjectWithData:data
                                                                      options:kNilOptions


### PR DESCRIPTION
I'm not 100% sure if the queue completion is only called once after all operations finished on very fast network connections, but I suppose that's an issue we can't work around, because of the NSOperationQueue's nature.