### PR TITLE
Add a recognizer for embed youtube urls

### DIFF
--- a/YoutubeParser/Classes/HCYoutubeParser.h
+++ b/YoutubeParser/Classes/HCYoutubeParser.h
@@ -71,6 +71,16 @@ typedef enum {
  */
 + (void)h264videosWithYoutubeURL:(NSURL *)youtubeURL
                    completeBlock:(void(^)(NSDictionary *videoDictionary, NSError *error))completeBlock;
+
+/**
+ Method for retreiving a thumbnail url for wanted youtube id
+ 
+ @param youtubeURL the complete youtube video id
+ @param thumbnailSize the wanted size of the thumbnail
+ */
++ (NSURL *)thumbnailUrlForYoutubeURL:(NSURL *)youtubeURL
+                         thumbnailSize:(YouTubeThumbnail)thumbnailSize;
+
 /**
  Method for retreiving a thumbnail for wanted youtube url
  

--- a/YoutubeParser/Classes/HCYoutubeParser.m
+++ b/YoutubeParser/Classes/HCYoutubeParser.m
@@ -97,7 +97,7 @@
     }else {
         youtubeID = [[[youtubeURL dictionaryForQueryString] objectForKey:@"v"] objectAtIndex:0];
     }
-
+    
     return youtubeID;
 }
 
@@ -224,6 +224,40 @@
     
     NSString *youtubeID = [self youtubeIDFromYoutubeURL:youtubeURL];
     return [self thumbnailForYoutubeID:youtubeID thumbnailSize:thumbnailSize completeBlock:completeBlock];
+}
+
++ (NSURL *)thumbnailUrlForYoutubeURL:(NSURL *)youtubeURL
+                         thumbnailSize:(YouTubeThumbnail)thumbnailSize{
+  NSURL *url = nil;
+  
+  if(youtubeURL){
+    
+    NSString *thumbnailSizeString = nil;
+    switch (thumbnailSize) {
+      case YouTubeThumbnailDefault:
+        thumbnailSizeString = @"default";
+        break;
+      case YouTubeThumbnailDefaultMedium:
+        thumbnailSizeString = @"mqdefault";
+        break;
+      case YouTubeThumbnailDefaultHighQuality:
+        thumbnailSizeString = @"hqdefault";
+        break;
+      case YouTubeThumbnailDefaultMaxQuality:
+        thumbnailSizeString = @"maxresdefault";
+        break;
+      default:
+        thumbnailSizeString = @"default";
+        break;
+    }
+    
+    NSString *youtubeID = [self youtubeIDFromYoutubeURL:youtubeURL];
+    
+    url = [NSURL URLWithString:[NSString stringWithFormat:kYoutubeThumbnailURL, youtubeID, thumbnailSizeString]];
+    
+  }
+  
+  return  url;
 }
 
 + (void)thumbnailForYoutubeID:(NSString *)youtubeID thumbnailSize:(YouTubeThumbnail)thumbnailSize completeBlock:(void (^)(UIImage *, NSError *))completeBlock {


### PR DESCRIPTION
This commit add support for a recognizer able to extract the youtube id from html5 file format (eg. http://youtube.com/embed/#ID#)
