### PR TITLE
Unique quality keys in the video dictionary

### DIFF
--- a/YoutubeParser/Classes/HCYoutubeParser.m
+++ b/YoutubeParser/Classes/HCYoutubeParser.m
@@ -139,9 +139,11 @@
                             url = [NSString stringWithFormat:@"%@&signature=%@", url, signature];
                             
                             NSString *quality = [[[videoComponents objectForKey:@"quality"] objectAtIndex:0] stringByDecodingURLFormat];
-                            
-                            NSLog(@"Found video for quality: %@", quality);
-                            [videoDictionary setObject:url forKey:quality];
+                            if([videoDictionary valueForKey:quality] == nil) { 
+                             
+                               NSLog(@"Found video for quality: %@", quality);
+                               [videoDictionary setObject:url forKey:quality];
+                            }
                         }
                     }
                 }
@@ -205,8 +207,11 @@
                             
                             NSString *quality = [[[videoComponents objectForKey:@"quality"] objectAtIndex:0] stringByDecodingURLFormat];
                             
-                            NSLog(@"Found video for quality: %@", quality);
-                            [videoDictionary setObject:url forKey:quality];
+                            if([videoDictionary valueForKey:quality] == nil) { 
+                             
+                               NSLog(@"Found video for quality: %@", quality);
+                               [videoDictionary setObject:url forKey:quality];
+                            }
                         }
                     }
                     dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
I had an issue that videoDictionary contained two equal keys, that broke the payback: two videos were playing at the same time instead of one. HCYoutubeParser should return videoDictionary with unique keys.
