### PR TITLE
Using different quality key for 3D vids

### DIFF
--- a/YoutubeParser/Classes/HCYoutubeParser.m
+++ b/YoutubeParser/Classes/HCYoutubeParser.m
@@ -137,6 +137,9 @@
                                 url = [NSString stringWithFormat:@"%@&signature=%@", url, signature];
 
                                 NSString *quality = [[[videoComponents objectForKey:@"quality"] objectAtIndex:0] stringByDecodingURLFormat];
+                                if ([videoComponents objectForKey:@"stereo3d"] && [[videoComponents objectForKey:@"stereo3d"] boolValue]) {
+                                    quality = [quality stringByAppendingString:@"-stereo3d"];
+                                }
                                 if([videoDictionary valueForKey:quality] == nil) {
                                     [videoDictionary setObject:url forKey:quality];
                                 }


### PR DESCRIPTION
New 3D videos use the same quality value as non-3D videos.  This makes sure to keep them separate when returning back the video dictionary.
