### PR TITLE
`stringByReplacingPercentEscapesUsingEncoding:` can return nil

### DIFF
--- a/YoutubeParser/Classes/HCYoutubeParser.m
+++ b/YoutubeParser/Classes/HCYoutubeParser.m
@@ -46,7 +46,7 @@
 - (NSString *)stringByDecodingURLFormat {
     NSString *result = [self stringByReplacingOccurrencesOfString:@"+" withString:@" "];
     result = [result stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    return result;
+    return result ?: @"";
 }
 
 - (NSMutableDictionary *)dictionaryFromQueryStringComponents {


### PR DESCRIPTION
so return an empty string if it returns nil

this is causing lots of crashes in production for us.
