### PR TITLE
Fixed tag name

### DIFF
--- a/HCYoutubeParser.podspec
+++ b/HCYoutubeParser.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description  = "HCYoutubeParser is a class which lets you get the iOS compatible video url from YouTube so you don't need to use a UIWebView or open the YouTube Application."
   s.homepage     = "https://github.com/hellozimi/HCYoutubeParser"
 
-  s.source       = { :git => "https://github.com/hellozimi/HCYoutubeParser.git", :tag => "v0.0.2" }
+  s.source       = { :git => "https://github.com/hellozimi/HCYoutubeParser.git", :tag => "0.0.2" }
 
   s.source_files = 'YoutubeParser/Classes'
   s.public_header_files = 'YoutubeParser/Classes/*.h'


### PR DESCRIPTION
Remove v in front of tag because tag name is “0.0.2” instead of “v0.0.2”
