### PR TITLE
Semaphore signal added to fix 'else' branch of youtube info parsing

### DIFF
--- a/YoutubeParser/Classes/HCYoutubeParser.m
+++ b/YoutubeParser/Classes/HCYoutubeParser.m
@@ -181,6 +181,11 @@
                     else if ([parts objectForKey:@"live_playback"] != nil && [parts objectForKey:@"hlsvp"] != nil && [[parts objectForKey:@"hlsvp"] count] > 0) {
                         data = @{ @"live": [parts objectForKey:@"hlsvp"][0] };
                         dispatch_semaphore_signal(semaphore);
+                        
+                    } else {
+                        
+                        //No data at all, just unlock the sema
+                        dispatch_semaphore_signal(semaphore);
                     }
                 }
             }


### PR DESCRIPTION
When I request the links with the following URL, the info cannot be obtained, so the semaphore will never unlock the thread. 

Example URL:
https://www.youtube.com/get_video_info?video_id=evWVzHSb4qY