### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > This project is not being maintained. 
 
-##HCYoutubeParser
+## HCYoutubeParser
 
 HCYoutubeParser is a class which lets you get the iOS compatible video url from YouTube so you don't need to use a `UIWebView` or open the YouTube Application.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
